### PR TITLE
feat: Adding git workflow to archive and upload the templates as part of release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -18,7 +18,7 @@ A clear and concise description of what you expected to happen.
 Tell us what actually happened.
 
 **Environment**
- - OS: [e.g. Ubuntu 20.04]
+ - OS: [e.g. Ubuntu 20.04] (If possible, provide output of `uname -a`)
  - JDK version:
  - Nucleus version:
 

--- a/.github/workflow/archive_template.yml
+++ b/.github/workflow/archive_template.yml
@@ -1,0 +1,41 @@
+# This workflow archives the templates from the git hub repository
+
+name: Archive
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Zip the templates
+        run: |
+          mkdir zip
+          # TODO: Add commands to zip the templates
+
+      - name: Upload zipped artifacts
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: templates
+          path: templates/*.zip
+
+      - name: Download uploaded artifacts
+        id: download
+        uses: actions/download-artifact@v2.0.10
+        with:
+          path: ~/download/
+
+      - name: Release
+        id: upload-release-asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{steps.download.outputs.download-path}}/templates/*.zip
+          tag_name: v1.0


### PR DESCRIPTION
**Issue #, if available:**
NA
**Description of changes:**
Added git workflow which creates zipped artifacts for templates in the repository and upload them to the release.
TODO: Zipping individual template

**Why is this change necessary:**
This is required to be able to download individual template as a zip file using `greengrass-tools`

**How was this change tested:**
This is tested on private repository.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.