### PR TITLE
fix: Fixed the workflow and corrected bucket and region for the template

### DIFF
--- a/.github/workflows/archive_template.yml
+++ b/.github/workflows/archive_template.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Zip the templates
+      - name: Archive the templates
         run: |
-          mkdir templates
+          mkdir archived-templates
           # TODO: Add commands to zip the templates
 
       - name: Upload zipped artifacts
         uses: actions/upload-artifact@v2.2.4
         with:
-          name: templates
-          path: templates/*.zip
+          name: archived-templates
+          path: archived-templates/*.zip
 
       - name: Download uploaded artifacts
         id: download
@@ -35,5 +35,5 @@ jobs:
         id: upload-release-asset
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{steps.download.outputs.download-path}}/templates/*.zip
+          files: ${{steps.download.outputs.download-path}}/archived-templates/*.zip
           tag_name: v1.0

--- a/templates/Java/HelloWorld/greengrass-tools-config.json
+++ b/templates/Java/HelloWorld/greengrass-tools-config.json
@@ -7,8 +7,8 @@
         "command" : ["default"]
       },
       "publish": {
-        "bucket": "default",
-        "region": "default"
+        "bucket": "<PLACEHOLDER_BUCKET>",
+        "region": "<PLACEHOLDER_REGION>"
       }
     }
   },


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Workflow was failing because `templates` folder exists in src. So renamed it to `archived-templates`
* Addressed comment to use PLACEHOLDER bucket and region name

**Why is this change necessary:**
* Workflow is failing currently, this fixes it

**How was this change tested:**
Tested by making this change in remote branch

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [X] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.