### PR TITLE
refactor: Renamed greengrass-tools-config file to gdk-config

### DIFF
--- a/templates/java/HelloWorld/gdk-config.json
+++ b/templates/java/HelloWorld/gdk-config.json
@@ -12,5 +12,5 @@
       }
     }
   },
-  "tools_version": "1.0.0"
+  "gdk_version": "1.0.0"
 }

--- a/templates/python/HelloWorld/gdk-config.json
+++ b/templates/python/HelloWorld/gdk-config.json
@@ -12,5 +12,5 @@
       }
     }
   },
-  "tools_version": "1.0.0"
+  "gdk_version": "1.0.0"
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
*  `greengrass-tools` is renamed to `gdk` and `greengrass-tools-config.json` is renamed to `gdk-config.json`

**Why is this change necessary:**
* With renaming of greengrass-tools, its necessary to change config file name for consistency.

**How was this change tested:**
* This is tested by locally running build.sh and will be tested with gdk

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.