### PR TITLE
fix: Correcting the folder structure for templates uploaded in releases

### DIFF
--- a/.github/workflows/archive_template.yml
+++ b/.github/workflows/archive_template.yml
@@ -16,15 +16,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Archive the templates
         run: |
-          mkdir archived-templates
-          zip -r archived-templates/HelloWorld-java.zip templates/java/HelloWorld/*
-          zip -r archived-templates/HelloWorld-python.zip templates/python/HelloWorld/*
+          mkdir ~/archived-templates
+          # Archive Java templates
+          cd templates/java
+          zip -r ~/archived-templates/HelloWorld-java.zip HelloWorld
+          # Archive Python templates
+          cd ../python
+          zip -r ~/archived-templates/HelloWorld-python.zip HelloWorld
 
       - name: Upload zipped artifacts
         uses: actions/upload-artifact@v2.2.4
         with:
           name: archived-templates
-          path: archived-templates/*.zip
+          path: ~/archived-templates/*.zip
 
       - name: Download uploaded artifacts
         id: download


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* The zip folder uploaded to releases, had templates/java or templates/python as parent directories. This change is to ensure that template zip file has only template contents.

**Why is this change necessary:**
* This change is required for CLI to get correct zip file.

**How was this change tested:**
* Tested by making change in remote branch and testing with GH workflow.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.