### PR TITLE
refactor(template): specify compiler version in pom

### DIFF
--- a/templates/java/HelloWorld/pom.xml
+++ b/templates/java/HelloWorld/pom.xml
@@ -11,6 +11,8 @@
   <properties>
     <junitVersion>5.5.2</junitVersion>
     <mavenPluginVersion>2.1</mavenPluginVersion>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Specify min jdk version to use in maven compiler plugin. 
 
**Why is this change necessary:**
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project HelloWorld: Compilation failure: Compilation failure: 
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
```

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.