### PR TITLE
fix: allow multiple arguments in the HelloWorld message

### DIFF
--- a/templates/python/HelloWorld/main.py
+++ b/templates/python/HelloWorld/main.py
@@ -3,8 +3,7 @@ import src.greeter as greeter
 
 def main():
     args = sys.argv[1:]
-    if len(args) == 1:
-        print(greeter.get_greeting(args[0]))
+    print(greeter.get_greeting(" ".join(args)))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
```
{"Message: "Test Message"}
```

Will currently not print anything at all, which is a very bad first user experience.

**Issue #, if available:**

**Description of changes:**

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.