### PR TITLE
fix: fix min gdk verision in HelloWorld py template

### DIFF
--- a/templates/python/LocalPubSub/gdk-config.json
+++ b/templates/python/LocalPubSub/gdk-config.json
@@ -12,5 +12,5 @@
       }
     }
   },
-  "gdk_version": "1.2.0"
+  "gdk_version": "1.0.0"
 }


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the minimum gdk version supported in the template. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.