### PR TITLE
chore: archive all the templates using python script

### DIFF
--- a/.github/workflows/archive_template.yml
+++ b/.github/workflows/archive_template.yml
@@ -13,17 +13,14 @@ jobs:
   archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Archive the templates
         run: |
-          mkdir ~/archived-templates
-          # Archive Java templates
-          cd templates/java
-          zip -r ~/archived-templates/HelloWorld-java.zip HelloWorld
-          # Archive Python templates
-          cd ../python
-          zip -r ~/archived-templates/HelloWorld-python.zip HelloWorld
-
+          python archive-templates.py
       - name: Upload zipped artifacts
         uses: actions/upload-artifact@v2.2.4
         with:

--- a/archive_templates.py
+++ b/archive_templates.py
@@ -1,0 +1,16 @@
+import shutil
+from pathlib import Path
+
+supported_languages = ["java", "python"]
+current_working_directory = Path("./").resolve()
+output_dir = Path.home().joinpath("archive-templates").resolve()
+Path.mkdir(output_dir, parents=True, exist_ok=True)
+
+for language in supported_languages:
+    templates_dir = Path(current_working_directory).joinpath("templates").joinpath(language).resolve()
+    templates_sub_dir = [file for file in templates_dir.iterdir() if file.is_dir()]
+    for template in templates_sub_dir:
+        zip_file_name = template.name + "-" + language
+        zip_file_path = Path(output_dir).joinpath(zip_file_name).resolve()
+        shutil.make_archive(zip_file_name, "zip", root_dir=template)
+        print("Created zip file for template " + zip_file_name)


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
- Use python script instead of shell to create archive templates. 
- Archive all the templates in the languages directory. 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.