### PR TITLE
chore: fix the archive templates file name

### DIFF
--- a/.github/workflows/archive_template.yml
+++ b/.github/workflows/archive_template.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.10'
       - name: Archive the templates
         run: |
-          python archive-templates.py
+          python archive_templates.py
       - name: Upload zipped artifacts
         uses: actions/upload-artifact@v2.2.4
         with:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fix the name of the archive templates file 

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.