### PR TITLE
feat: create test template for gdk cli

### DIFF
--- a/templates/java/TestTemplateForCLI/pom.xml
+++ b/templates/java/TestTemplateForCLI/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.aws.greengrass</groupId>
+  <artifactId>uat-features</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0</version>
+  <name>OTF</name>
+  
+  <properties>
+    <otf.version>1.1.0-SNAPSHOT</otf.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>greengrass-common</id>
+      <name>greengrass common</name>
+      <!-- CloudFront url fronting the aws-greengrass-testing-standalone in S3-->
+      <url>https://d2jrmugq4soldf.cloudfront.net/snapshots</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <!-- Open Testing Framework dependency - Source Code: https://github.com/aws-greengrass/aws-greengrass-testing -->
+    <dependency>
+      <groupId>com.aws.greengrass</groupId>
+      <artifactId>aws-greengrass-testing-standalone</artifactId>
+      <version>{otf.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.aws.greengrass.testing.launcher.TestLauncher</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/templates/java/TestTemplateForCLI/src/main/java/com/aws/greengrass/CustomSteps.java
+++ b/templates/java/TestTemplateForCLI/src/main/java/com/aws/greengrass/CustomSteps.java
@@ -1,0 +1,17 @@
+package com.aws.greengrass;
+
+import io.cucumber.guice.ScenarioScoped;
+import io.cucumber.java.en.And;
+
+/**
+ * Change this or create a file like this one to define custom steps to test functionality
+ * specific to your component
+ */
+@ScenarioScoped
+public class CustomSteps {
+
+    @And("I call my custom step")
+    public void customStep() {
+        System.out.println("My custom step was called ");
+    }
+}

--- a/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/component.feature
+++ b/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/component.feature
@@ -1,0 +1,13 @@
+Feature: Testing features of Greengrassv2 GDK_COMPONENT_NAME
+
+    Background:
+        Given my device is registered as a Thing
+        And my device is running Greengrass
+
+    @Sample
+    Scenario: As a developer, I can create a component and deploy it on my device
+        When I create a Greengrass deployment with components
+            | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+        And I deploy the Greengrass deployment configuration
+        Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+        And I call my custom step


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This testing template is used by GDK CLI only. As this won't be added to the CLI templates list, it can't be downloaded by customers using `gdk component init` command.
However, GDK CLI downloads this testing module into existing GDK project when it is initialized with testing command `gdk test init` . 




**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.