### PR TITLE
fix: otf version in the test template

### DIFF
--- a/templates/java/TestTemplateForCLI/pom.xml
+++ b/templates/java/TestTemplateForCLI/pom.xml
@@ -10,7 +10,7 @@
   <name>OTF</name>
   
   <properties>
-    <otf.version>1.1.0-SNAPSHOT</otf.version>
+    <otf.version>GDK_TESTING_VERSION</otf.version>
   </properties>
 
   <repositories>
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.aws.greengrass</groupId>
       <artifactId>aws-greengrass-testing-standalone</artifactId>
-      <version>{otf.version}</version>
+      <version>${otf.version}</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Use variable `GDK_TESTING_VERSION` which will be replaced in the `gdk test build` command. Fix version property in the pom.

**Why is this change necessary:**

**How was this change tested:**

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.