### PR TITLE
feat: add four confidence tests to template

### DIFF
--- a/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/confidenceTest.feature
+++ b/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/confidenceTest.feature
@@ -1,0 +1,70 @@
+Feature: Confidence Test Suite
+
+  Background:
+    Given my device is registered as a Thing
+    And my device is running Greengrass
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device and see it is working as expected
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    And I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME and restart Greengrass to check if it is still working as expected
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I restart Greengrass
+    Then I wait 5 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    And I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device and see it is working as expected after an additional local deployment to change component configuration
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}.
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    # Update the MERGE deployment configuration with the intended key-value pairs.
+    And I update my local deployment configuration, setting the component GDK_COMPONENT_NAME configuration to:
+      """
+        {
+          "MERGE": {
+            "configurationKey": "keyValue"
+          }
+        }
+      """
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}. Additional verification steps may be added here too.
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device with configuration updates and see it is working as expected
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    # Update the MERGE deployment configuration with the intended key-value pairs.
+    And I update my Greengrass deployment configuration, setting the component GDK_COMPONENT_NAME configuration to:
+      """
+        {
+          "MERGE": {
+            "configurationKey": "keyValue"
+          }
+        }
+      """
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}. Additional verification steps may be added here too.
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Add four confidence tests to the template. Specifically, these four are the ones that do not require new steps in GTF.
- Basic deployment test
- Verification that component works after GG restarts (test from PR: https://github.com/aws-greengrass/aws-greengrass-component-templates/pull/40, added again as that change was reverted)
- Local configuration deployment test
- Initial cloud configuration deployment test

**Why is this change necessary:**
Provides a set of generic tests that component developers can use or tweak.

**How was this change tested:**
First tested in GTF itself. I also created my own GDK project with a hello world template and added these tests to the template provided by the test-e2e command, built, and ran the tests. In both cases, tests ran and passed for the generic simple components.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.