### PR TITLE
feat: complete confidence test suite with additional four tests

### DIFF
--- a/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/confidenceTest.feature
+++ b/templates/java/TestTemplateForCLI/src/main/resources/greengrass/features/confidenceTest.feature
@@ -15,6 +15,22 @@ Feature: Confidence Test Suite
     And I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
 
   @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME, stop it and start it again
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I use greengrass-cli to stop the component GDK_COMPONENT_NAME
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is FINISHED using the greengrass-cli
+    When I use greengrass-cli to restart the component GDK_COMPONENT_NAME
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+
+  @ConfidenceTest
   Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME and restart Greengrass to check if it is still working as expected
     When I create a Greengrass deployment with components
       | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
@@ -27,6 +43,24 @@ Feature: Confidence Test Suite
     Then I wait 5 seconds
     # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
     And I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME and disable internet to check if component is working. Restore internet to check if component is still working
+    When I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I set device network connectivity to OFFLINE
+    And I restart Greengrass
+    Then I wait 5 seconds
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I set device network connectivity to ONLINE
+    # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
 
   @ConfidenceTest
   Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device and see it is working as expected after an additional local deployment to change component configuration
@@ -46,8 +80,9 @@ Feature: Confidence Test Suite
           }
         }
       """
+    Then the local Greengrass deployment is SUCCEEDED on the device after 120 seconds
     # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}. Additional verification steps may be added here too.
-    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    And I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
 
   @ConfidenceTest
   Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device with configuration updates and see it is working as expected
@@ -67,4 +102,29 @@ Feature: Confidence Test Suite
     Then the Greengrass deployment is COMPLETED on the device after 180 seconds
     # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}. Additional verification steps may be added here too.
     Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
-    
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device and verify device RAM has not increased by more than a specified threshold
+    When I record the device's RAM usage statistic as RAM1
+    And I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+  # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I record the device's RAM usage statistic as RAM2
+    Then the increase in the RAM usage from RAM1 to RAM2 is less than 1024 MB
+
+  @ConfidenceTest
+  Scenario: As a Developer, I can deploy GDK_COMPONENT_NAME to my device and verify device CPU usage has not increased by more than a specified threshold
+    When I record the device's CPU usage statistic as CPU1
+    And I create a Greengrass deployment with components
+      | GDK_COMPONENT_NAME | GDK_COMPONENT_RECIPE_FILE |
+      | aws.greengrass.Cli | LATEST                    |
+    And I deploy the Greengrass deployment configuration
+    Then the Greengrass deployment is COMPLETED on the device after 180 seconds
+  # Update component state accordingly. Possible states: {RUNNING, FINISHED, BROKEN, STOPPING}
+    Then I verify the GDK_COMPONENT_NAME component is RUNNING using the greengrass-cli
+    When I record the device's CPU usage statistic as CPU2
+    Then the increase in the CPU usage from CPU1 to CPU2 is less than 25 percent


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Adds four more confidence tests to the confidence test suite, completing the set of component confidence tests. They are:

- Deploying, starting, and stopping the component (from https://github.com/aws-greengrass/aws-greengrass-component-templates/pull/40)
- Checking component behavior during network outage (from https://github.com/aws-greengrass/aws-greengrass-component-templates/pull/40)
- Approximate ambient RAM use test
- Approximate ambient CPU use test

Also added an additional step to the existing local deployment test, verifying that the local deployment is completed.

**Why is this change necessary:**
Completes the confidence test suite with 8 total confidence tests.

**How was this change tested:**
Since the above tests are reliant on GTF 1.2.0, the tests were tested using the gdk test-e2e command with GTF version 1.2.0 set in the gdk config file. After pulling down the existing template, the new tests were added and verified to be running against a modified version of HelloWorld that was made to be in state RUNNING after deployment.

**Any additional information or context required to review the change:**
Requires GTF 1.2.0--merge PR after GDK 1.6.0 release which sets the default version of GTF used by GDK to 1.2.0.

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.