### PR TITLE
feat: templates now generates artifacts based on component name

### DIFF
--- a/templates/python/HelloWorld/gdk-config.json
+++ b/templates/python/HelloWorld/gdk-config.json
@@ -15,5 +15,5 @@
       }
     }
   },
-  "gdk_version": "1.0.0"
+  "gdk_version": "1.3.0"
 }

--- a/templates/python/HelloWorld/gdk-config.json
+++ b/templates/python/HelloWorld/gdk-config.json
@@ -4,7 +4,10 @@
       "author": "<PLACEHOLDER_AUTHOR>",
       "version": "NEXT_PATCH",
       "build": {
-        "build_system": "zip"
+        "build_system": "zip",
+        "options": {
+          "zip_name": ""
+        }
       },
       "publish": {
         "bucket": "<PLACEHOLDER_BUCKET>",

--- a/templates/python/HelloWorld/recipe.yaml
+++ b/templates/python/HelloWorld/recipe.yaml
@@ -11,7 +11,7 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld.zip"
+      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonHelloWorld.zip"
         Unarchive: ZIP
     Lifecycle:
-      Run: "python3 -u {artifacts:decompressedPath}/HelloWorld/main.py {configuration:/Message}"
+      Run: "python3 -u {artifacts:decompressedPath}/com.example.PythonHelloWorld/main.py {configuration:/Message}"

--- a/templates/python/LocalPubSub/gdk-config.json
+++ b/templates/python/LocalPubSub/gdk-config.json
@@ -15,5 +15,5 @@
       }
     }
   },
-  "gdk_version": "1.0.0"
+  "gdk_version": "1.3.0"
 }

--- a/templates/python/LocalPubSub/gdk-config.json
+++ b/templates/python/LocalPubSub/gdk-config.json
@@ -4,7 +4,10 @@
       "author": "<PLACEHOLDER_AUTHOR>",
       "version": "NEXT_PATCH",
       "build": {
-        "build_system": "zip"
+        "build_system": "zip",
+        "options": {
+          "zip_name": ""
+        }
       },
       "publish": {
         "bucket": "<PLACEHOLDER_BUCKET>",

--- a/templates/python/LocalPubSub/recipe.yaml
+++ b/templates/python/LocalPubSub/recipe.yaml
@@ -21,7 +21,7 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/LocalPubSub.zip"
+      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonLocalPubSub.zip"
         Unarchive: ZIP
     Lifecycle:
-      Run: "python3 -u {artifacts:decompressedPath}/LocalPubSub/main.py {configuration:/Topic} {configuration:/Message}"
+      Run: "python3 -u {artifacts:decompressedPath}/com.example.PythonLocalPubSub/main.py {configuration:/Topic} {configuration:/Message}"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update templates so that we are creating the zip using the component name, not the directory name.

**Why is this change necessary:**
This should allow project directories to be named differently without producing errors.

**How was this change tested:**
Manually tested the two projects after changing bucket and region and ensured the build worked.

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.