### PR TITLE
chore: update recipe casing for os field

### DIFF
--- a/templates/java/HelloWorld/recipe.yaml
+++ b/templates/java/HelloWorld/recipe.yaml
@@ -9,7 +9,7 @@ ComponentConfiguration:
     Message: "World"
 Manifests:
   - Platform:
-      os: all
+      OS: all
     Artifacts:
       - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld-1.0.0.jar"
     Lifecycle:

--- a/templates/java/LocalPubSub/recipe.yaml
+++ b/templates/java/LocalPubSub/recipe.yaml
@@ -19,7 +19,7 @@ ComponentConfiguration:
             - "/topic/local/pubsub"
 Manifests:
   - Platform:
-      os: all
+      OS: all
     Artifacts:
       - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/LocalPubSub-1.0.0.jar"
     Lifecycle:

--- a/templates/java/TestingFramework/component/recipe.yaml
+++ b/templates/java/TestingFramework/component/recipe.yaml
@@ -6,7 +6,7 @@ ComponentDescription: "This is simple Hello World component written in Java."
 ComponentPublisher: "{COMPONENT_AUTHOR}"
 Manifests:
   - Platform:
-      os: all
+      OS: all
     Artifacts:
       - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/Component-1.0.0-SNAPSHOT.jar"
     Lifecycle:

--- a/templates/python/HelloWorld/recipe.yaml
+++ b/templates/python/HelloWorld/recipe.yaml
@@ -9,7 +9,7 @@ ComponentConfiguration:
     Message: "World"
 Manifests:
   - Platform:
-      os: all
+      OS: all
     Artifacts:
       - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonHelloWorld.zip"
         Unarchive: ZIP

--- a/templates/python/LocalPubSub/recipe.yaml
+++ b/templates/python/LocalPubSub/recipe.yaml
@@ -19,7 +19,7 @@ ComponentConfiguration:
             - "/topic/local/pubsub"
 Manifests:
   - Platform:
-      os: all
+      OS: all
     Artifacts:
       - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonLocalPubSub.zip"
         Unarchive: ZIP


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the casing for the os field in template recipes from "os" to "OS".

**Why is this change necessary:**
We are updating casings for certain fields within Greengrass recipes, and these templates include the old casing for the os field.

**How was this change tested:**
N/A

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.