### PR TITLE
chore: update recipe casing for run lifecycle and artifact uri

### DIFF
--- a/templates/java/HelloWorld/recipe.yaml
+++ b/templates/java/HelloWorld/recipe.yaml
@@ -11,6 +11,6 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld-1.0.0.jar"
+      - Uri: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/HelloWorld-1.0.0.jar"
     Lifecycle:
-      Run: "java -cp {artifacts:path}/HelloWorld-1.0.0.jar com.hello.App {configuration:/Message}"
+      run: "java -cp {artifacts:path}/HelloWorld-1.0.0.jar com.hello.App {configuration:/Message}"

--- a/templates/java/LocalPubSub/recipe.yaml
+++ b/templates/java/LocalPubSub/recipe.yaml
@@ -21,6 +21,6 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/LocalPubSub-1.0.0.jar"
+      - Uri: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/LocalPubSub-1.0.0.jar"
     Lifecycle:
-      Run: "java -cp {artifacts:path}/LocalPubSub-1.0.0.jar com.localpubsub.App '{configuration:/Topic}' '{configuration:/Message}'"
+      run: "java -cp {artifacts:path}/LocalPubSub-1.0.0.jar com.localpubsub.App '{configuration:/Topic}' '{configuration:/Message}'"

--- a/templates/java/TestingFramework/component/recipe.yaml
+++ b/templates/java/TestingFramework/component/recipe.yaml
@@ -8,6 +8,6 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/Component-1.0.0-SNAPSHOT.jar"
+      - Uri: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/Component-1.0.0-SNAPSHOT.jar"
     Lifecycle:
-      Run: "java -cp {artifacts:path}/Component-1.0.0-SNAPSHOT.jar com.templates.otf.App"
+      run: "java -cp {artifacts:path}/Component-1.0.0-SNAPSHOT.jar com.templates.otf.App"

--- a/templates/python/HelloWorld/recipe.yaml
+++ b/templates/python/HelloWorld/recipe.yaml
@@ -11,7 +11,7 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonHelloWorld.zip"
+      - Uri: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonHelloWorld.zip"
         Unarchive: ZIP
     Lifecycle:
-      Run: "python3 -u {artifacts:decompressedPath}/com.example.PythonHelloWorld/main.py {configuration:/Message}"
+      run: "python3 -u {artifacts:decompressedPath}/com.example.PythonHelloWorld/main.py {configuration:/Message}"

--- a/templates/python/LocalPubSub/recipe.yaml
+++ b/templates/python/LocalPubSub/recipe.yaml
@@ -21,7 +21,7 @@ Manifests:
   - Platform:
       os: all
     Artifacts:
-      - URI: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonLocalPubSub.zip"
+      - Uri: "s3://BUCKET_NAME/COMPONENT_NAME/COMPONENT_VERSION/com.example.PythonLocalPubSub.zip"
         Unarchive: ZIP
     Lifecycle:
-      Run: "python3 -u {artifacts:decompressedPath}/com.example.PythonLocalPubSub/main.py {configuration:/Topic} {configuration:/Message}"
+      run: "python3 -u {artifacts:decompressedPath}/com.example.PythonLocalPubSub/main.py {configuration:/Topic} {configuration:/Message}"


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Update the casing in sample recipes for templates from "Run" to "run" for the lifecycle step.

**Why is this change necessary:**
Greengrass Lite which was released yesterday enforces case sensitivity for recipes. This will allow new components created using GDK templates to have the supported casing for the "run" lifecycle.

**How was this change tested:**
N/A

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.