### PR TITLE
chore: update github workflow versions

### DIFF
--- a/.github/workflows/archive_template.yml
+++ b/.github/workflows/archive_template.yml
@@ -29,14 +29,14 @@ jobs:
           zip -r ~/archived-templates/LocalPubSub-python.zip LocalPubSub
 
       - name: Upload zipped artifacts
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: archived-templates
           path: ~/archived-templates/*.zip
 
       - name: Download uploaded artifacts
         id: download
-        uses: actions/download-artifact@v2.0.10
+        uses: actions/download-artifact@v4.1.8
         with:
           path: ~/download/
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Bump up workflow versions to latest as the old versions were deprecated and do not work.

Checked documentation here for breaking changes: https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md. We don't need to use any of the new features and just bumping versions succeeded when testing the action out manually.

**Why is this change necessary:**
We need these workflows to update the released template artifacts.

**How was this change tested:**
Manually ran the workflow: https://github.com/aws-greengrass/aws-greengrass-component-templates/actions/runs/12400896794

**Any additional information or context required to review the change:**

**Checklist:**
- [ ] Updated the README if applicable
- [ ] Updated or added new unit tests
- [ ] Updated or added new integration tests
- [ ] Updated or added new end-to-end tests
- [ ] If your code makes a remote network call, it was tested with a proxy
- [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.